### PR TITLE
configure config file & peer id

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,8 @@ Usage:
 Flags:
       --auth-token string     Authorization token to validate signing requests
   -h, --help                  help for daemon
-      --relay-maddr string    Multiaddress of libp2p relay
+      --private-key string    Libp2p private key
+      --relay-maddr string    Multiaddress of libp2p relay (default "/ip4/34.105.85.147/tcp/4001/p2p/QmYRDEq8z3Y9hBBAirwMFySuxyCoWwskrD1bxUEYKBiwmU")
       --wallet-keys strings   Wallet address keys; repeatable
 
 Global Flags:
@@ -91,9 +92,33 @@ The first log lines of the daemon will help understanding which wallet public ke
 2021-09-10T10:07:10.955-0300    INFO    auc     auc/walletCmd.go:70     Relayed multiaddr: /ip4/140.20.1.1/tcp/9898/p2p/QmfPveoYMS158VbkxNeizZ3ZrDWHb82R28xfkVT9QodcQA/p2p-circuit/Qma7rzaZUYNgqSkhgrQ8dmBhPvBhuGk3W7gm1MnoK2Bj9U
 2021-09-10T10:07:30.956-0300    DEBUG   relaymgr        relaymgr/relaymgr.go:104        relay connection is healthy
 ```
-
 The relay multiaddress circuit is useful to augment your reachable multiaddresses of the remote wallet 
+
+
+### Remote signing direct-auction API
 for the _direct auctions_ API calls.
+
+An example of the body for a direct-auction API call:
+```json
+{
+   "payloadCid":"...",
+   "pieceCid":"...",
+   "pieceSize":...,
+   "repFactor":...,
+   "deadline":"...",
+   "carURL":{...},
+   "remoteWallet":{
+      # These three fields are mandatory.
+      "peerID":"Qma7rzaZUYNgqSkhgrQ8dmBhPvBhuGk3W7gm1MnoK2Bj9U",
+      "authToken":"mysecrettk",
+      "walletAddr":"f3rpskqryflc2sqzzzu7j2q6fecrkdkv4p2avpf4kyk5u754he7g6cr2rbpmif7pam5oxbme2oyzot4ry3d74q",
+      
+      # This is an optional but *highly recommended* field.
+      # If empty only the relayed address will be used, but for better reliability
+      # is encouraged to open ports and provide additional reachable multiaddresses.
+      "multiAddrs": ["...", "..."], 
+   }
+```
 
 ## Remote signing library
 

--- a/cmd/auc/main.go
+++ b/cmd/auc/main.go
@@ -45,7 +45,7 @@ func init() {
 	cli.ConfigureCLI(v, envPrefix, []cli.Flag{
 		{Name: "wallet-keys", DefValue: []string{}, Description: "Wallet address keys"},
 		{Name: "auth-token", DefValue: "", Description: "Authorization token to validate signing requests"},
-		{Name: "relay-maddr", DefValue: "", Description: "Multiaddress of libp2p relay"},
+		{Name: "relay-maddr", DefValue: "/ip4/34.105.85.147/tcp/4001/p2p/QmYRDEq8z3Y9hBBAirwMFySuxyCoWwskrD1bxUEYKBiwmU", Description: "Multiaddress of libp2p relay"},
 		{Name: "listen-maddr", DefValue: "", Description: "Libp2p listen multiaddr"},
 	}, walletDaemonCmd.Flags())
 }

--- a/cmd/auc/main.go
+++ b/cmd/auc/main.go
@@ -1,10 +1,14 @@
 package main
 
 import (
+	"crypto/rand"
+	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
 
+	"github.com/libp2p/go-libp2p-core/crypto"
+	"github.com/multiformats/go-multibase"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 	"github.com/textileio/cli"
@@ -31,7 +35,12 @@ func init() {
 		v.SetConfigName("config")
 		v.AddConfigPath(os.Getenv(envPrefix + "_PATH"))
 		v.AddConfigPath(configPath)
-		_ = v.ReadInConfig()
+		if err := initConfigFile(configPath); err != nil {
+			log.Infof("config file can't be read, creating one")
+		}
+		if err := v.ReadInConfig(); err != nil {
+			log.Fatalf("reading config file: %s", err)
+		}
 	})
 
 	// Commands.
@@ -45,8 +54,17 @@ func init() {
 	cli.ConfigureCLI(v, envPrefix, []cli.Flag{
 		{Name: "wallet-keys", DefValue: []string{}, Description: "Wallet address keys"},
 		{Name: "auth-token", DefValue: "", Description: "Authorization token to validate signing requests"},
-		{Name: "relay-maddr", DefValue: "/ip4/34.105.85.147/tcp/4001/p2p/QmYRDEq8z3Y9hBBAirwMFySuxyCoWwskrD1bxUEYKBiwmU", Description: "Multiaddress of libp2p relay"},
+		{
+			Name:        "relay-maddr",
+			DefValue:    "/ip4/34.105.85.147/tcp/4001/p2p/QmYRDEq8z3Y9hBBAirwMFySuxyCoWwskrD1bxUEYKBiwmU",
+			Description: "Multiaddress of libp2p relay",
+		},
 		{Name: "listen-maddr", DefValue: "", Description: "Libp2p listen multiaddr"},
+		{
+			Name:        "private-key",
+			DefValue:    "",
+			Description: "Libp2p private key",
+		},
 	}, walletDaemonCmd.Flags())
 }
 
@@ -59,4 +77,35 @@ var rootCmd = &cobra.Command{
 
 func main() {
 	cli.CheckErr(rootCmd.Execute())
+}
+
+func initConfigFile(configPath string) error {
+	path := filepath.Join(configPath, "config")
+	if _, err := os.Stat(path); err == nil {
+		return nil
+	}
+	if err := os.MkdirAll(filepath.Dir(path), os.ModePerm); err != nil {
+		log.Fatalf("create config file path: %s", err)
+	}
+
+	if v.GetString("private-key") == "" {
+		priv, _, err := crypto.GenerateEd25519Key(rand.Reader)
+		if err != nil {
+			return fmt.Errorf("generating private key: %v", err)
+		}
+		key, err := crypto.MarshalPrivateKey(priv)
+		if err != nil {
+			return fmt.Errorf("marshaling private key: %v", err)
+		}
+		keystr, err := multibase.Encode(multibase.Base64, key)
+		if err != nil {
+			return fmt.Errorf("encoding private key: %v", err)
+		}
+		v.Set("private-key", keystr)
+	}
+	if err := v.WriteConfigAs(path); err != nil {
+		log.Fatalf("creating config file: %s", err)
+	}
+
+	return nil
 }

--- a/go.mod
+++ b/go.mod
@@ -13,6 +13,7 @@ require (
 	github.com/libp2p/go-libp2p-core v0.8.5
 	github.com/libp2p/go-libp2p-swarm v0.5.0
 	github.com/multiformats/go-multiaddr v0.3.3
+	github.com/multiformats/go-multibase v0.0.3
 	github.com/multiformats/go-varint v0.0.6
 	github.com/spf13/cobra v1.2.1
 	github.com/spf13/viper v1.8.1
@@ -164,7 +165,6 @@ require (
 	github.com/multiformats/go-multiaddr-dns v0.3.1 // indirect
 	github.com/multiformats/go-multiaddr-fmt v0.1.0 // indirect
 	github.com/multiformats/go-multiaddr-net v0.2.0 // indirect
-	github.com/multiformats/go-multibase v0.0.3 // indirect
 	github.com/multiformats/go-multihash v0.0.15 // indirect
 	github.com/multiformats/go-multistream v0.2.2 // indirect
 	github.com/nkovacs/streamquote v0.0.0-20170412213628-49af9bddb229 // indirect


### PR DESCRIPTION
Remote wallets should have a stable PeerID since direct-auctions API calls reference them as targets for deal proposal signatures.
Here we do some work to:
- Autocreate config files, so this can be managed there (plus other configuration knobs).
- Autogenerate a stable peer-id if none is provided.
This way future runs `auc wallet daemon` after the first one will have a stable peer id (unless is explicitly set via `--private-key`, which is totally fine if the client knows what's doing).

Also, as planned, the production relay maddr is configured as the default flag value.